### PR TITLE
fix: enhance minishell with readline and improved Makefile closes#3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.ko
 *.obj
 *.elf
+/build
 
 # Linker output
 *.ilk

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #    By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/27 10:00:00 by seu_login         #+#    #+#              #
-#    Updated: 2025/05/31 10:55:14 by nbuchhol         ###   ########.fr        #
+#    Updated: 2025/05/31 14:00:19 by nbuchhol         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
@@ -45,8 +45,8 @@ RESET = \033[0m
 LIBFT = $(LIBFT_DIR)/libft.a
 
 HEADERS = $(INCDIR)/minishell.h \
-#		  $(INCDIR)/lexer.h \
-		  $(INCDIR)/parser.h \
+		  $(INCDIR)/lexer.h \
+#		  $(INCDIR)/parser.h \
 		  $(INCDIR)/executor.h \
 		  $(INCDIR)/builtins.h
 

--- a/Makefile
+++ b/Makefile
@@ -6,20 +6,29 @@
 #    By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+         #
 #                                                 +#+#+#+#+#+   +#+            #
 #    Created: 2025/05/27 10:00:00 by seu_login         #+#    #+#              #
-#    Updated: 2025/05/30 21:26:45 by nbuchhol         ###   ########.fr        #
+#    Updated: 2025/05/31 10:55:14 by nbuchhol         ###   ########.fr        #
 #                                                                              #
 # **************************************************************************** #
 
 NAME = minishell
 
 CC = cc
-CFLAGS = -Wall -Wextra -Werror -g3
+CFLAGS = -Wall -Wextra -Werror -g3 -MMD -MP
 READLINE_FLAGS = -lreadline
+MAKEFLAGS += --no-print-directory
+
+#******************************************************************************#
+#                                   PATH                                       #
+#******************************************************************************#
 
 SRCDIR = src
-OBJDIR = obj
+OBJDIR = build
 INCDIR = includes
 LIBFT_DIR = libft
+
+#******************************************************************************#
+#                                   COLOR                                      #
+#******************************************************************************#
 
 GREEN = \033[0;32m
 YELLOW = \033[0;33m
@@ -28,6 +37,10 @@ BLUE = \033[0;34m
 PURPLE = \033[0;35m
 CYAN = \033[0;36m
 RESET = \033[0m
+
+#******************************************************************************#
+#                                   FILES                                      #
+#******************************************************************************#
 
 LIBFT = $(LIBFT_DIR)/libft.a
 
@@ -86,51 +99,52 @@ SRC = $(MAIN_SRC) \
 	  $(HISTORY_SRC)
 
 OBJ = $(addprefix $(OBJDIR)/, $(SRC:.c=.o))
+DEPS = $(addprefix $(OBJDIR)/, $(SRC:.c=.d))
 
 all: $(NAME)
 
 $(NAME): $(LIBFT) $(OBJ)
-	@$(CC) $(CFLAGS) $(OBJ) -L$(LIBFT_DIR) -lft $(READLINE_FLAGS) -o $(NAME)
-	@echo "$(GREEN)Minishell compiled successfully!$(RESET)"
+	$(CC) $(CFLAGS) $(OBJ) -L$(LIBFT_DIR) -lft $(READLINE_FLAGS) -o $(NAME)
+	echo "$(GREEN)Minishell compiled successfully!$(RESET)"
 
 $(LIBFT):
-	@echo "$(YELLOW)Compiling libft...$(RESET)"
-	@$(MAKE) -C $(LIBFT_DIR)
-	@echo "$(GREEN)Libft compiled!$(RESET)"
+	echo "$(YELLOW)Compiling libft...$(RESET)"
+	$(MAKE) -C $(LIBFT_DIR)
+	echo "$(GREEN)Libft compiled!$(RESET)"
 
-$(OBJDIR)/%.o: $(SRCDIR)/%.c $(HEADERS) | $(OBJDIR)
-	@mkdir -p $(dir $@)
-	@$(CC) $(CFLAGS) -I$(INCDIR) -I$(LIBFT_DIR) -c $< -o $@
-	@echo "$(BLUE)Compiling: $(notdir $<)$(RESET)"
+$(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
+	mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) -I$(INCDIR) -I$(LIBFT_DIR) -c $< -o $@
+	echo "$(BLUE)Compiling: $(notdir $<)$(RESET)"
 
 $(OBJDIR):
-	@mkdir -p $(OBJDIR)
-	@mkdir -p $(OBJDIR)/lexer
-	@mkdir -p $(OBJDIR)/parser
-	@mkdir -p $(OBJDIR)/executor
-	@mkdir -p $(OBJDIR)/builtins
-	@mkdir -p $(OBJDIR)/environment
-	@mkdir -p $(OBJDIR)/history
+	mkdir -p $(OBJDIR)
+	mkdir -p $(OBJDIR)/lexer
+	mkdir -p $(OBJDIR)/parser
+	mkdir -p $(OBJDIR)/executor
+	mkdir -p $(OBJDIR)/builtins
+	mkdir -p $(OBJDIR)/environment
+	mkdir -p $(OBJDIR)/history
 
 clean:
-	@$(MAKE) -C $(LIBFT_DIR) clean
-	@rm -rf $(OBJDIR)
-	@echo "$(RED)Objects removed$(RESET)"
+	$(MAKE) -C $(LIBFT_DIR) clean
+	rm -rf $(OBJDIR)
+	echo "$(RED)Objects and Deps removed$(RESET)"
 
 fclean: clean
-	@$(MAKE) -C $(LIBFT_DIR) fclean
-	@rm -f $(NAME)
-	@echo "$(RED)Executable $(NAME) removed$(RESET)"
+	$(MAKE) -C $(LIBFT_DIR) fclean
+	rm -f $(NAME)
+	echo "$(RED)Executable $(NAME) removed$(RESET)"
 
 re: fclean all
-	@echo "$(CYAN)Project recompiled!$(RESET)"
+	echo "$(CYAN)Project recompiled!$(RESET)"
 
 debug: CFLAGS += -fsanitize=address -DDEBUG
 debug: re
-	@echo "$(PURPLE)Debug version compiled with Address Sanitizer$(RESET)"
+	echo "$(PURPLE)Debug version compiled with Address Sanitizer$(RESET)"
 
 norm:
-	@if command -v norminette >/dev/null 2>&1; then \
+	if command -v norminette >/dev/null 2>&1; then \
 		echo "$(YELLOW)Checking norm...$(RESET)"; \
 		norminette $(SRCDIR) $(INCDIR); \
 	else \
@@ -138,12 +152,14 @@ norm:
 	fi
 
 help:
-	@echo "$(CYAN)Available commands:$(RESET)"
-	@echo "$(GREEN)  make           $(RESET)- Compile project"
-	@echo "$(GREEN)  make clean     $(RESET)- Remove objects"
-	@echo "$(GREEN)  make fclean    $(RESET)- Remove all"
-	@echo "$(GREEN)  make re        $(RESET)- Recompile all"
-	@echo "$(GREEN)  make debug     $(RESET)- Compile with debug"
-	@echo "$(GREEN)  make norm      $(RESET)- Check norm"
+	echo "$(CYAN)Available commands:$(RESET)"
+	echo "$(GREEN)  make           $(RESET)- Compile project"
+	echo "$(GREEN)  make clean     $(RESET)- Remove objects"
+	echo "$(GREEN)  make fclean    $(RESET)- Remove all"
+	echo "$(GREEN)  make re        $(RESET)- Recompile all"
+	echo "$(GREEN)  make debug     $(RESET)- Compile with debug"
+	echo "$(GREEN)  make norm      $(RESET)- Check norm"
 
+-include $(DEPS)
 .PHONY: all clean fclean re debug norm help
+.SILENT:

--- a/includes/lexer.h
+++ b/includes/lexer.h
@@ -1,0 +1,32 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   lexer.h                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/05/31 14:00:53 by nbuchhol          #+#    #+#             */
+/*   Updated: 2025/05/31 14:23:35 by nbuchhol         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#ifndef LEXER_H
+# define LEXER_H
+# include "minishell.h"
+
+typedef enum e_token_type
+{
+	TOKEN_WORD,
+	TOKEN_PIPE,
+	TOKEN_REDIR_IN,
+	TOKEN_REDIR_OUT
+}					t_token_type;
+
+typedef struct s_token
+{
+	t_token_type	type;
+	char			*value;
+	struct s_token	*next;
+}					t_token;
+
+#endif

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 10:59:25 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/05/30 22:17:04 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/05/31 14:24:21 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,26 +17,14 @@
 # include <readline/readline.h>
 # include <stdio.h>
 
-typedef enum e_token_type
-{
-	TOKEN_WORD,
-	TOKEN_PIPE,
-	TOKEN_REDIR_IN,
-	TOKEN_REDIR_OUT
-}					t_token_type;
-
-typedef struct s_token
-{
-	t_token_type	type;
-	char			*value;
-	struct s_token	*next;
-}					t_token;
-
 typedef struct s_shell
 {
-	char			*input;
-	t_token			*tokens;
-	int				exit_status;
-}					t_shell;
+	char	*input;
+	int		exit_status;
+	int		should_exit;
+}			t_shell;
+
+int			shell_loop(t_shell *shell);
+int			process_input(t_shell *shell);
 
 #endif

--- a/src/init.c
+++ b/src/init.c
@@ -6,6 +6,19 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 08:33:56 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/05/27 08:33:57 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/05/31 14:50:14 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
+
+#include "minishell.h"
+
+/**
+ * @brief Process the input and send to lexer analysis.
+ * @param t_shell pointer to base struct to shell variables.
+ * @return 1 if the shell should exit, otherwise 0.
+ */
+int	process_input(t_shell *shell)
+{
+	printf("Você digitou: %s\n", shell->input);
+	return (0);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -6,25 +6,43 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 08:33:52 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/05/30 16:52:40 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/05/31 14:54:53 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
 
+/**
+ * @brief Handles the readline loop.
+ * @param t_shell pointer to base struct to shell variables.
+ * @return 1 if the shell should exit, otherwise 0.
+ */
+int	shell_loop(t_shell *shell)
+{
+	while (!shell->should_exit)
+	{
+		shell->input = readline("minishell> ");
+		if (!shell->input)
+		{
+			shell->should_exit = 1;
+			break ;
+		}
+		if (shell->input && *(shell->input))
+		{
+			add_history(shell->input);
+			process_input(shell);
+		}
+		free(shell->input);
+		shell->input = NULL;
+	}
+	return (shell->should_exit);
+}
+
 int	main(void)
 {
-	char	*input;
+	t_shell	shell;
 
-	while (1)
-	{
-		input = readline("minishell> ");
-		if (!input)
-			break ;
-		if (*input)
-			add_history(input);
-		printf("Você digitou: %s\n", input);
-		free(input);
-	}
+	ft_memset(&shell, 0, sizeof(t_shell));
+	shell_loop(&shell);
 	return (0);
 }


### PR DESCRIPTION
Integrate readline for input processing in the main shell function, define essential structures, and enhance the Makefile for better output and dependency tracking. Exclude the build directory from version control.