### PR TITLE
Add operator type recognition and update token enumeration

### DIFF
--- a/includes/lexer.h
+++ b/includes/lexer.h
@@ -6,7 +6,7 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/31 14:00:53 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/06/02 17:22:10 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/06/02 20:46:22 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,7 +20,8 @@ typedef enum e_token_type
 	TOKEN_PIPE,
 	TOKEN_REDIR_IN,
 	TOKEN_REDIR_OUT,
-	TOKEN_REDIR_APPEND
+	TOKEN_REDIR_APPEND,
+	TOKEN_HEREDOC
 }					t_token_type;
 
 typedef struct s_token

--- a/src/lexer/lexer_utils.c
+++ b/src/lexer/lexer_utils.c
@@ -6,7 +6,7 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/01 11:59:48 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/06/02 20:48:31 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/06/02 20:49:59 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,16 +23,6 @@ int	skip_whitespace(char *input, int pos)
 	while (input[pos] && ft_isspace(input[pos]))
 		pos++;
 	return (pos);
-}
-
-/**
- * @brief Check if character is a shell operator metacharacter.
- * @param c Character to check.
- * @return 1 if operator, 0 otherwise.
- */
-int	is_operator(char c)
-{
-	return (c == '|' || c == '<' || c == '>');
 }
 
 /**

--- a/src/lexer/lexer_utils.c
+++ b/src/lexer/lexer_utils.c
@@ -6,7 +6,7 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/01 11:59:48 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/06/02 17:33:38 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/06/02 20:48:31 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -43,25 +43,6 @@ int	is_operator(char c)
 int	is_metacharacter(char c)
 {
 	return (ft_isspace(c) || is_operator(c));
-}
-
-/**
- * @brief Get token type based on string content.
- * @param char* Pointer to current position in string.
- * @param int index of the current position in string.
- * @return Corresponding token type enum.
- */
-t_token_type	get_operator_type(char *input, int pos)
-{
-	if (input[pos + 1] && input[pos] == '>' && input[pos + 1] == '>')
-		return (TOKEN_REDIR_APPEND);
-	if (input[pos] == '|')
-		return (TOKEN_PIPE);
-	if (input[pos] == '<')
-		return (TOKEN_REDIR_IN);
-	if (input[pos] == '>')
-		return (TOKEN_REDIR_OUT);
-	return (TOKEN_WORD);
 }
 
 /**

--- a/src/lexer/operators.c
+++ b/src/lexer/operators.c
@@ -6,11 +6,21 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/02 20:41:28 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/06/02 20:48:41 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/06/02 20:50:06 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "lexer.h"
+
+/**
+ * @brief Check if character is a shell operator metacharacter.
+ * @param c Character to check.
+ * @return 1 if operator, 0 otherwise.
+ */
+int	is_operator(char c)
+{
+	return (c == '|' || c == '<' || c == '>');
+}
 
 /**
  * @brief Get token type based on string content.

--- a/src/lexer/operators.c
+++ b/src/lexer/operators.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   operators.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/06/02 20:41:28 by nbuchhol          #+#    #+#             */
+/*   Updated: 2025/06/02 20:48:41 by nbuchhol         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "lexer.h"
+
+/**
+ * @brief Get token type based on string content.
+ * @param char* Pointer to current position in string.
+ * @param int index of the current position in string.
+ * @return Corresponding token type enum.
+ */
+t_token_type	get_operator_type(char *input, int pos)
+{
+	if (input[pos + 1] && input[pos] == '>' && input[pos + 1] == '>')
+		return (TOKEN_REDIR_APPEND);
+	if (input[pos + 1] && input[pos] == '<' && input[pos + 1] == '<')
+		return (TOKEN_HEREDOC);
+	if (input[pos] == '|')
+		return (TOKEN_PIPE);
+	if (input[pos] == '<')
+		return (TOKEN_REDIR_IN);
+	if (input[pos] == '>')
+		return (TOKEN_REDIR_OUT);
+	return (TOKEN_WORD);
+}


### PR DESCRIPTION
Introduce the `TOKEN_HEREDOC` to the token type enumeration and implement functions to identify shell operator metacharacters in a new `operators.c` file. This enhances the lexer functionality for better parsing of shell commands.