### PR TITLE
fix:SIGQUIT signal handler for interactive mode

### DIFF
--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -6,7 +6,7 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 10:59:25 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/07/10 13:15:58 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/07/11 20:17:20 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,8 @@
 # include <stdio.h>
 # include <signal.h>
 # include <stdlib.h>
+# include <sys/types.h>
+# include <unistd.h>
 
 typedef struct s_shell
 {

--- a/src/main.c
+++ b/src/main.c
@@ -6,7 +6,7 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 08:33:52 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/07/11 11:29:51 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/07/11 20:17:20 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -29,6 +29,7 @@ static char	**init_shell_env(t_shell *shell, char **envp)
 		return (NULL);
 	}
 	shell->envp = env;
+	rl_catch_signals = 0;
 	if (setup_interactive_signals() != 0)
 	{
 		free_cpy_env(env);

--- a/src/signals.c
+++ b/src/signals.c
@@ -6,7 +6,7 @@
 /*   By: nbuchhol <nbuchhol@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 08:33:44 by nbuchhol          #+#    #+#             */
-/*   Updated: 2025/07/10 12:10:58 by nbuchhol         ###   ########.fr       */
+/*   Updated: 2025/07/11 20:17:20 by nbuchhol         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,6 +28,21 @@ static void	handle_sigint(int sig)
 }
 
 /**
+ * @brief Signal handler for SIGQUIT (Ctrl+\)
+ * @param sig Signal number
+ */
+static void	handle_sigquit(int sig)
+{
+	(void)sig;
+	if (rl_line_buffer && rl_line_buffer[0] != '\0')
+	{
+		write(STDOUT_FILENO, "\nQuit (core dumped)\n", 20);
+		exit(131);
+	}
+	/* If no text in buffer, do nothing (ignore the signal) */
+}
+
+/**
  * @brief Setup signal handlers for interactive mode
  * @return 0 on success, 1 on error
  */
@@ -44,9 +59,9 @@ int	setup_interactive_signals(void)
 		perror("minishell: sigaction SIGINT");
 		return (1);
 	}
-	sa_quit.sa_handler = SIG_IGN;
+	sa_quit.sa_handler = handle_sigquit;
 	sigemptyset(&sa_quit.sa_mask);
-	sa_quit.sa_flags = 0;
+	sa_quit.sa_flags = SA_RESTART;
 	if (sigaction(SIGQUIT, &sa_quit, NULL) == -1)
 	{
 		perror("minishell: sigaction SIGQUIT");


### PR DESCRIPTION
Implement a signal handler for SIGQUIT to manage user interruptions more gracefully in the interactive shell environment. Update signal handling setup accordingly.